### PR TITLE
Update jackson.core to 2.9.9 to remove security warnings

### DIFF
--- a/com.eclipsesource.modelserver.emf/pom.xml
+++ b/com.eclipsesource.modelserver.emf/pom.xml
@@ -44,7 +44,7 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.9.8</version>
+			<version>2.9.9</version>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>


### PR DESCRIPTION
Gets rid of security warning