### PR TITLE
Deactivate java-doc generation for now

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,38 +113,39 @@
 							</execution>
 						</executions>
 					</plugin>
-					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-javadoc-plugin</artifactId>
-						<version>3.1.0</version>
-						<executions>
-							<execution>
-								<id>attach-javadocs</id>
-								<goals>
-									<goal>jar</goal>
-								</goals>
-								<configuration>
-									<tags>
-										<tag>
-											<name>generated</name>
-											<placement>a</placement>
-											<head></head>
-										</tag>
-											<tag>
-											<name>ordered</name>
-											<placement>a</placement>
-											<head></head>
-										</tag>
-											<tag>
-											<name>model</name>
-											<placement>a</placement>
-											<head>Model:</head>
-										</tag>
-									</tags>
-								</configuration>
-							</execution>
-						</executions>
-					</plugin>
+<!--  Uncomment this for deploying releases -->
+<!-- 					<plugin> -->
+<!-- 						<groupId>org.apache.maven.plugins</groupId> -->
+<!-- 						<artifactId>maven-javadoc-plugin</artifactId> -->
+<!-- 						<version>3.1.0</version> -->
+<!-- 						<executions> -->
+<!-- 							<execution> -->
+<!-- 								<id>attach-javadocs</id> -->
+<!-- 								<goals> -->
+<!-- 									<goal>jar</goal> -->
+<!-- 								</goals> -->
+<!-- 								<configuration> -->
+<!-- 									<tags> -->
+<!-- 										<tag> -->
+<!-- 											<name>generated</name> -->
+<!-- 											<placement>a</placement> -->
+<!-- 											<head></head> -->
+<!-- 										</tag> -->
+<!-- 											<tag> -->
+<!-- 											<name>ordered</name> -->
+<!-- 											<placement>a</placement> -->
+<!-- 											<head></head> -->
+<!-- 										</tag> -->
+<!-- 											<tag> -->
+<!-- 											<name>model</name> -->
+<!-- 											<placement>a</placement> -->
+<!-- 											<head>Model:</head> -->
+<!-- 										</tag> -->
+<!-- 									</tags> -->
+<!-- 								</configuration> -->
+<!-- 							</execution> -->
+<!-- 						</executions> -->
+<!-- 					</plugin> -->
 
 					<!-- To sign the artifacts -->
 					<plugin>


### PR DESCRIPTION
Fix for failing Travis build.

The JDK11 version used by Travis has a known bug with the maven-java-doc plugin.
This got already fixed in newer JDK releases. Can be reactivated once Travis updates to a new version.