### PR TITLE
Support different formats

### DIFF
--- a/com.eclipsesource.modelserver.common/src/main/java/com/eclipsesource/modelserver/jsonschema/Json.java
+++ b/com.eclipsesource.modelserver.common/src/main/java/com/eclipsesource/modelserver/jsonschema/Json.java
@@ -56,6 +56,14 @@ public class Json {
 
     public static ArrayNode array() { return mapper.createArrayNode(); }
 
+    public static ArrayNode array(JsonNode... json) {
+        final ArrayNode arrayNode = mapper.createArrayNode();
+        for (JsonNode node : json) {
+            arrayNode.add(node);
+        }
+        return arrayNode;
+    }
+
     public static ArrayNode array(List<String> list) {
         final ArrayNode array = mapper.createArrayNode();
         list.forEach(array::add);

--- a/com.eclipsesource.modelserver.emf/pom.xml
+++ b/com.eclipsesource.modelserver.emf/pom.xml
@@ -58,6 +58,12 @@
 			<version>2.9.0</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>com.eclipsesource.modelserver</groupId>
+			<artifactId>com.eclipsesource.modelserver.coffee.model</artifactId>
+			<version>0.0.1-SNAPSHOT</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 

--- a/com.eclipsesource.modelserver.emf/src/main/java/com/eclipsesource/modelserver/emf/common/ModelRepository.java
+++ b/com.eclipsesource.modelserver.emf/src/main/java/com/eclipsesource/modelserver/emf/common/ModelRepository.java
@@ -15,12 +15,7 @@
  *******************************************************************************/
 package com.eclipsesource.modelserver.emf.common;
 
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EObject;
@@ -60,8 +55,8 @@ public class ModelRepository {
 		return loadModel(modeluri);
 	}
 
-	public Set<Entry<URI, EObject>> getAllModels() {
-		return this.models.entrySet();
+	public Map<URI, EObject> getAllModels() {
+		return new LinkedHashMap<>(this.models);
 	}
 
 	public void addModel(String modeluri, EObject model) {

--- a/com.eclipsesource.modelserver.emf/src/main/java/com/eclipsesource/modelserver/emf/common/codecs/Codec.java
+++ b/com.eclipsesource.modelserver.emf/src/main/java/com/eclipsesource/modelserver/emf/common/codecs/Codec.java
@@ -1,0 +1,24 @@
+/*******************************************************************************
+ * Copyright (c) 2019 EclipseSource and others.
+ *
+ *   This program and the accompanying materials are made available under the
+ *   terms of the Eclipse Public License v. 2.0 which is available at
+ *   http://www.eclipse.org/legal/epl-2.0.
+ *
+ *   This Source Code may also be made available under the following Secondary
+ *   Licenses when the conditions for such availability set forth in the Eclipse
+ *   Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ *   with the GNU Classpath Exception which is available at
+ *   https://www.gnu.org/software/classpath/license.html.
+ *
+ *   SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ *******************************************************************************/
+package com.eclipsesource.modelserver.emf.common.codecs;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.eclipse.emf.ecore.EObject;
+
+public interface Codec {
+
+    JsonNode encode(EObject eObject) throws EncodingException;
+}

--- a/com.eclipsesource.modelserver.emf/src/main/java/com/eclipsesource/modelserver/emf/common/codecs/Encoder.java
+++ b/com.eclipsesource.modelserver.emf/src/main/java/com/eclipsesource/modelserver/emf/common/codecs/Encoder.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2019 EclipseSource and others.
+ *
+ *   This program and the accompanying materials are made available under the
+ *   terms of the Eclipse Public License v. 2.0 which is available at
+ *   http://www.eclipse.org/legal/epl-2.0.
+ *
+ *   This Source Code may also be made available under the following Secondary
+ *   Licenses when the conditions for such availability set forth in the Eclipse
+ *   Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ *   with the GNU Classpath Exception which is available at
+ *   https://www.gnu.org/software/classpath/license.html.
+ *
+ *   SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ *******************************************************************************/
+package com.eclipsesource.modelserver.emf.common.codecs;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.javalin.http.Context;
+import org.eclipse.emf.ecore.EObject;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+
+public class Encoder {
+
+    private Map<String, Codec> formatToCodec = new LinkedHashMap<>();
+
+    public Encoder() {
+        formatToCodec.put("xmi", new XmiCodec());
+        formatToCodec.put("json", new JsonCodec());
+    }
+
+    public JsonNode encode(Context context, EObject eObject) throws EncodingException {
+        return findFormat(context).encode(eObject);
+    }
+
+    private Codec findFormat(Context ctx) {
+        return Optional
+            .ofNullable(ctx.queryParam("format"))
+            .flatMap(f -> Optional.ofNullable(formatToCodec.get(f)))
+            .orElse(new JsonCodec());
+    }
+}

--- a/com.eclipsesource.modelserver.emf/src/main/java/com/eclipsesource/modelserver/emf/common/codecs/EncodingException.java
+++ b/com.eclipsesource.modelserver.emf/src/main/java/com/eclipsesource/modelserver/emf/common/codecs/EncodingException.java
@@ -1,0 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2019 EclipseSource and others.
+ *
+ *   This program and the accompanying materials are made available under the
+ *   terms of the Eclipse Public License v. 2.0 which is available at
+ *   http://www.eclipse.org/legal/epl-2.0.
+ *
+ *   This Source Code may also be made available under the following Secondary
+ *   Licenses when the conditions for such availability set forth in the Eclipse
+ *   Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ *   with the GNU Classpath Exception which is available at
+ *   https://www.gnu.org/software/classpath/license.html.
+ *
+ *   SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ *******************************************************************************/
+package com.eclipsesource.modelserver.emf.common.codecs;
+
+public class EncodingException extends Exception {
+
+    public EncodingException(Exception underlyingCause) {
+        super(underlyingCause);
+    }
+}

--- a/com.eclipsesource.modelserver.emf/src/main/java/com/eclipsesource/modelserver/emf/common/codecs/JsonCodec.java
+++ b/com.eclipsesource.modelserver.emf/src/main/java/com/eclipsesource/modelserver/emf/common/codecs/JsonCodec.java
@@ -13,42 +13,23 @@
  *
  *   SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  *******************************************************************************/
-package com.eclipsesource.modelserver.emf.common;
+package com.eclipsesource.modelserver.emf.common.codecs;
 
-import org.jetbrains.annotations.Nullable;
-
-import com.eclipsesource.modelserver.jsonschema.Json;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-
 import io.javalin.plugin.json.JavalinJackson;
+import org.eclipse.emf.ecore.EObject;
 
-public class JsonResponse {
+public class JsonCodec implements Codec {
 
-	public static JsonNode success(ObjectNode response) {
-		final ObjectNode success = Json.object(
-			Json.prop("type", Json.text("success"))
-		);
-		return Json.merge(success, response);
-	}
+    public JsonNode encode(EObject obj) throws EncodingException {
+        return encode((Object) obj);
+    }
 
-	public static ObjectNode error(String message) {
-		return Json.object(
-			Json.prop("type", Json.text("error")),
-			Json.prop("message", Json.text(message))
-		);
-	}
-
-	public static JsonNode data(@Nullable JsonNode jsonNode) {
-		return Json.object(
-			Json.prop("data", jsonNode)
-		);
-	}
-
-	public static JsonNode confirm(String message) {
-		return Json.object(
-			Json.prop("type", Json.text("confirm")),
-			Json.prop("message", Json.text(message))
-		);
-	}
+    public static JsonNode encode(Object obj) throws EncodingException {
+        try {
+            return JavalinJackson.getObjectMapper().valueToTree(obj);
+        } catch (IllegalArgumentException ex) {
+            throw new EncodingException(ex);
+        }
+    }
 }

--- a/com.eclipsesource.modelserver.emf/src/main/java/com/eclipsesource/modelserver/emf/common/codecs/XmiCodec.java
+++ b/com.eclipsesource.modelserver.emf/src/main/java/com/eclipsesource/modelserver/emf/common/codecs/XmiCodec.java
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Copyright (c) 2019 EclipseSource and others.
+ *
+ *   This program and the accompanying materials are made available under the
+ *   terms of the Eclipse Public License v. 2.0 which is available at
+ *   http://www.eclipse.org/legal/epl-2.0.
+ *
+ *   This Source Code may also be made available under the following Secondary
+ *   Licenses when the conditions for such availability set forth in the Eclipse
+ *   Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ *   with the GNU Classpath Exception which is available at
+ *   https://www.gnu.org/software/classpath/license.html.
+ *
+ *   SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ *******************************************************************************/
+package com.eclipsesource.modelserver.emf.common.codecs;
+
+import com.eclipsesource.modelserver.jsonschema.Json;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.emf.ecore.resource.ResourceSet;
+import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
+import org.eclipse.emf.ecore.xmi.impl.XMIResourceFactoryImpl;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+public class XmiCodec implements Codec {
+
+    public JsonNode encode(EObject eObject) throws EncodingException {
+        ResourceSet resourceSet = new ResourceSetImpl();
+        resourceSet
+            .getResourceFactoryRegistry()
+            .getProtocolToFactoryMap()
+            .put(null, new XMIResourceFactoryImpl());
+
+        final Resource resource = resourceSet.createResource(URI.createURI("virtual.xmi"));
+        resource.getContents().add(eObject);
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        try {
+            resource.save(outputStream, null);
+        } catch (IOException e) {
+            throw new EncodingException(e);
+        }
+
+        return Json.text(outputStream.toString());
+    }
+
+}

--- a/com.eclipsesource.modelserver.emf/src/test/java/com/eclipsesource/modelserver/emf/common/ModelControllerTest.java
+++ b/com.eclipsesource.modelserver.emf/src/test/java/com/eclipsesource/modelserver/emf/common/ModelControllerTest.java
@@ -1,0 +1,112 @@
+/*******************************************************************************
+ * Copyright (c) 2019 EclipseSource and others.
+ *
+ *   This program and the accompanying materials are made available under the
+ *   terms of the Eclipse Public License v. 2.0 which is available at
+ *   http://www.eclipse.org/legal/epl-2.0.
+ *
+ *   This Source Code may also be made available under the following Secondary
+ *   Licenses when the conditions for such availability set forth in the Eclipse
+ *   Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ *   with the GNU Classpath Exception which is available at
+ *   https://www.gnu.org/software/classpath/license.html.
+ *
+ *   SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ *******************************************************************************/
+package com.eclipsesource.modelserver.emf.common;
+
+import com.eclipsesource.modelserver.coffee.model.coffee.BrewingUnit;
+import com.eclipsesource.modelserver.coffee.model.coffee.CoffeeFactory;
+import com.eclipsesource.modelserver.emf.common.codecs.EncodingException;
+import com.eclipsesource.modelserver.emf.common.codecs.JsonCodec;
+import com.eclipsesource.modelserver.emf.common.codecs.XmiCodec;
+import com.eclipsesource.modelserver.jsonschema.Json;
+import com.fasterxml.jackson.databind.JsonNode;
+import io.javalin.http.Context;
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.EObject;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.stubbing.Answer;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.*;
+
+public class ModelControllerTest {
+
+    private ModelRepository modelRepository;
+    private Context context;
+    private ModelController modelController;
+
+    @Before
+    public void before() {
+        modelRepository = mock(ModelRepository.class);
+        context = mock(Context.class);
+        SessionController sessionController = mock(SessionController.class);
+        modelController = new ModelController(modelRepository, sessionController);
+    }
+
+    @Test
+    public void getOneXmiFormat() throws EncodingException {
+        final AtomicReference<JsonNode> response = new AtomicReference<>();
+        final BrewingUnit brewingUnit = CoffeeFactory.eINSTANCE.createBrewingUnit();
+        Answer<Void> answer = invocation -> {
+            response.set(invocation.getArgument(0));
+            return null;
+        };
+        doAnswer(answer).when(context).json(any(JsonNode.class));
+        when(context.queryParam("format")).thenReturn("xmi");
+        when(modelRepository.getModel("test")).thenReturn(Optional.of(brewingUnit));
+
+        modelController.getOne(context, "test");
+
+        assertThat(response.get().get("data"), is(equalTo(new XmiCodec().encode(brewingUnit))));
+    }
+
+    @Test
+    public void getAllXmiFormat() throws EncodingException {
+        final AtomicReference<JsonNode> response = new AtomicReference<>();
+        final BrewingUnit brewingUnit = CoffeeFactory.eINSTANCE.createBrewingUnit();
+        Answer<Void> answer = invocation -> {
+            response.set(invocation.getArgument(0));
+            return null;
+        };
+        doAnswer(answer).when(context).json(any(JsonNode.class));
+        when(context.queryParam("format")).thenReturn("xmi");
+        final Map<URI, EObject> allModels =
+            Collections.singletonMap(URI.createURI("test"), brewingUnit);
+        when(modelRepository.getAllModels()).thenReturn(allModels);
+
+        modelController.getAll(context);
+
+        assertThat(response.get().get("data"), is(equalTo(
+            Json.object(
+                Json.prop("test", new XmiCodec().encode(brewingUnit))
+            )
+        )));
+    }
+
+    @Test
+    public void getOneJsonFormat() throws EncodingException {
+        final AtomicReference<JsonNode> response = new AtomicReference<>();
+        final BrewingUnit brewingUnit = CoffeeFactory.eINSTANCE.createBrewingUnit();
+        Answer<Void> answer = invocation -> {
+            response.set(invocation.getArgument(0));
+            return null;
+        };
+        doAnswer(answer).when(context).json(any(JsonNode.class));
+        when(modelRepository.getModel("test")).thenReturn(Optional.of(brewingUnit));
+
+        modelController.getOne(context, "test");
+
+        assertThat(response.get().get("data"), is(equalTo(new JsonCodec().encode(brewingUnit))));
+    }
+}


### PR DESCRIPTION
* Add a basic `codecs` package that is used to serialize `EObjects` to
  JSON nodes. XMI is serialized as string.
* Remove encoding from `Json#data`.
* Let `{Model,Session}Controller` handle encoding based on context.
* Add additional `array` method to `Json`.
* Change return type of `ModelController#getAll` to `Map`

For requesting data in a different format, use the `format` query parameter, e.g. `/api/v1/SuperBrewer3000.json?format=xmi`