### PR TITLE
Add p2-generation and deployment to travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,13 @@ deploy:
   script: mvn deploy -s ./settings.xml -U -DskipTests -Prelease
   on:
     branch: master
+after_deploy:
+        - cd  scripts
+        - ./deploy-p2.sh
+addons:
+    apt:
+      packages:
+        - libxml2-utils
 branches:
   only:
   - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,8 @@ deploy:
   on:
     branch: master
 after_deploy:
-        - cd  scripts
-        - ./deploy-p2.sh
+   - cd scripts
+   - ./deploy-p2.sh
 addons:
     apt:
       packages:

--- a/scripts/deploy-p2.sh
+++ b/scripts/deploy-p2.sh
@@ -4,7 +4,7 @@ REPO_DIR=$ROOT_DIR/.repo
 
 rm -rf $REPO_DIR
 mkdir $REPO_DIR
-# Clone glsp-p2 and switch to new skeleton branch
+# Clone modelserver-p2 and switch to new skeleton branch
 cd $REPO_DIR || exit
 git clone  https://github.com/eclipsesource/modelserver-p2.git
 cd modelserver-p2 || exit

--- a/scripts/deploy-p2.sh
+++ b/scripts/deploy-p2.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )"/.. && pwd )"
+REPO_DIR=$ROOT_DIR/.repo
+
+rm -rf $REPO_DIR
+mkdir $REPO_DIR
+# Clone glsp-p2 and switch to new skeleton branch
+cd $REPO_DIR || exit
+git clone  https://github.com/eclipsesource/modelserver-p2.git
+cd modelserver-p2 || exit
+
+git checkout plugin_skeleton
+git checkout -b new_deploy
+
+# (Re)generate plugis
+cd scripts || exit
+. ./functions.sh
+. ./generate.sh
+
+rm -rf $REPO_DIR


### PR DESCRIPTION
Each Travis build of the master branch now triggers p2 generation and deployment after successful deployment of the maven artifacts. (similar to GLSP)

Used a separate branch with special configuration to test this (since the deployment phase is not triggered on PRs).
(https://github.com/eclipsesource/modelserver/tree/testbranch)
Build was successful and the p2 artifacts are available here:
https://dl.bintray.com/eclipsesource/modelserver/nightly/