### PR TITLE
Support different formats for update

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,16 @@ client.get("SuperBrewer3000.json?format=xmi")
       
 // perform POST
 client.update("SuperBrewer3000.json", "{ \"data\": <payload> }")
-      .thenAccept(response -> System.out.println(response.body()));      
+      .thenAccept(response -> System.out.println(response.body()));
+
+// perform POST with XMI format
+client.update("SuperBrewer3000.json?format=xmi", client.encode(brewingUnit, "xmi"))
+  .thenAccept(response -> {
+    client.get("SuperBrewer3000.json?format=xmi").thenAccept(resp -> {
+      System.out.println(client.decode(resp.body(), "xmi"));
+    });
+  });
+}
 ```
 
 ### Subscriptions Example

--- a/com.eclipsesource.modelserver.client/src/main/java/com/eclipsesource/modelserver/client/ModelServerClientApiV1.java
+++ b/com.eclipsesource.modelserver.client/src/main/java/com/eclipsesource/modelserver/client/ModelServerClientApiV1.java
@@ -26,7 +26,7 @@ public interface ModelServerClientApiV1 {
 
     CompletableFuture<Response<Boolean>> delete(String modelUri);
 
-    CompletableFuture<Response<String>> update(String modelUri, String updatedModel, String mediaType);
+    CompletableFuture<Response<String>> update(String modelUri, String updatedModel);
 
     CompletableFuture<Response<String>> getSchema(String modelUri);
 

--- a/com.eclipsesource.modelserver.client/src/test/java/com/eclipsesource/modelserver/client/ModelServerClientTest.java
+++ b/com.eclipsesource.modelserver.client/src/test/java/com/eclipsesource/modelserver/client/ModelServerClientTest.java
@@ -18,7 +18,7 @@ package com.eclipsesource.modelserver.client;
 import com.eclipsesource.modelserver.coffee.model.coffee.CoffeeFactory;
 import com.eclipsesource.modelserver.coffee.model.coffee.Display;
 import com.eclipsesource.modelserver.emf.common.JsonResponse;
-import com.eclipsesource.modelserver.emf.common.codecs.EncodingException;
+import com.eclipsesource.modelserver.common.codecs.EncodingException;
 import com.eclipsesource.modelserver.emf.common.codecs.JsonCodec;
 import com.eclipsesource.modelserver.jsonschema.Json;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -106,8 +106,7 @@ public class ModelServerClientTest {
 
         final CompletableFuture<Response<String>> f = client.update(
             "SuperBrewer3000.json",
-            expected.toString(),
-            "application/json"
+            expected.toString()
         );
 
         assertThat(f.get().body(), equalTo(expected.toString()));

--- a/com.eclipsesource.modelserver.common/pom.xml
+++ b/com.eclipsesource.modelserver.common/pom.xml
@@ -56,6 +56,16 @@
 			<artifactId>org.eclipse.emf.ecore</artifactId>
 			<version>2.15.0</version>
 		</dependency>
+        <dependency>
+            <groupId>org.eclipse.emf</groupId>
+            <artifactId>org.eclipse.emf.ecore.xmi</artifactId>
+            <version>2.15.0</version>
+        </dependency>
+		<dependency>
+			<groupId>org.emfjson</groupId>
+			<artifactId>emfjson-jackson</artifactId>
+			<version>1.2.0</version>
+		</dependency>
 	</dependencies>
 
 	<!-- Additional required metadata for deploying releases to mvn central -->

--- a/com.eclipsesource.modelserver.common/src/main/java/com/eclipsesource/modelserver/common/codecs/Codec.java
+++ b/com.eclipsesource.modelserver.common/src/main/java/com/eclipsesource/modelserver/common/codecs/Codec.java
@@ -13,11 +13,15 @@
  *
  *   SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  *******************************************************************************/
-package com.eclipsesource.modelserver.emf.common.codecs;
+package com.eclipsesource.modelserver.common.codecs;
 
-public class EncodingException extends Exception {
+import com.fasterxml.jackson.databind.JsonNode;
+import org.eclipse.emf.ecore.EObject;
 
-    public EncodingException(Exception underlyingCause) {
-        super(underlyingCause);
-    }
+import java.util.Optional;
+
+public interface Codec {
+
+    JsonNode encode(EObject eObject) throws EncodingException;
+    Optional<EObject> decode(String payload) throws DecodingException;
 }

--- a/com.eclipsesource.modelserver.common/src/main/java/com/eclipsesource/modelserver/common/codecs/DecodingException.java
+++ b/com.eclipsesource.modelserver.common/src/main/java/com/eclipsesource/modelserver/common/codecs/DecodingException.java
@@ -13,12 +13,12 @@
  *
  *   SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  *******************************************************************************/
-package com.eclipsesource.modelserver.emf.common.codecs;
+package com.eclipsesource.modelserver.common.codecs;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import org.eclipse.emf.ecore.EObject;
+public class DecodingException extends Exception {
 
-public interface Codec {
-
-    JsonNode encode(EObject eObject) throws EncodingException;
+    public DecodingException(Exception underlyingCause) {
+        super(underlyingCause);
+    }
 }
+

--- a/com.eclipsesource.modelserver.common/src/main/java/com/eclipsesource/modelserver/common/codecs/DefaultJsonCodec.java
+++ b/com.eclipsesource.modelserver.common/src/main/java/com/eclipsesource/modelserver/common/codecs/DefaultJsonCodec.java
@@ -13,24 +13,31 @@
  *
  *   SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  *******************************************************************************/
-package com.eclipsesource.modelserver.emf.common.codecs;
+package com.eclipsesource.modelserver.common.codecs;
 
-import com.eclipsesource.modelserver.common.codecs.DefaultJsonCodec;
-import com.eclipsesource.modelserver.common.codecs.EncodingException;
 import com.fasterxml.jackson.databind.JsonNode;
-import io.javalin.plugin.json.JavalinJackson;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.eclipse.emf.ecore.EObject;
 
-public class JsonCodec extends DefaultJsonCodec {
+import java.util.Optional;
 
-    @Override
+public class DefaultJsonCodec implements Codec {
+
+    final EMFJsonConverter emfJsonConverter = new EMFJsonConverter();
+
     public JsonNode encode(EObject obj) throws EncodingException {
         return encode((Object) obj);
     }
 
+    @Override
+    public Optional<EObject> decode(String payload) {
+        return emfJsonConverter.fromJson(payload);
+    }
+
     public static JsonNode encode(Object obj) throws EncodingException {
         try {
-            return JavalinJackson.getObjectMapper().valueToTree(obj);
+            ObjectMapper mapper = new ObjectMapper();
+            return mapper.valueToTree(obj);
         } catch (IllegalArgumentException ex) {
             throw new EncodingException(ex);
         }

--- a/com.eclipsesource.modelserver.common/src/main/java/com/eclipsesource/modelserver/common/codecs/EMFJsonConverter.java
+++ b/com.eclipsesource.modelserver.common/src/main/java/com/eclipsesource/modelserver/common/codecs/EMFJsonConverter.java
@@ -13,7 +13,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-package com.eclipsesource.modelserver.emf;
+package com.eclipsesource.modelserver.common.codecs;
 
 import java.io.IOException;
 import java.text.SimpleDateFormat;
@@ -23,12 +23,12 @@ import java.util.TimeZone;
 
 import org.apache.log4j.Logger;
 import org.eclipse.emf.ecore.EObject;
-import org.emfjson.jackson.module.EMFModule;
 
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import org.emfjson.jackson.module.EMFModule;
 
 public class EMFJsonConverter {
 	private static Logger LOG = Logger.getLogger(EMFJsonConverter.class.getSimpleName());

--- a/com.eclipsesource.modelserver.common/src/main/java/com/eclipsesource/modelserver/common/codecs/EncodingException.java
+++ b/com.eclipsesource.modelserver.common/src/main/java/com/eclipsesource/modelserver/common/codecs/EncodingException.java
@@ -13,26 +13,11 @@
  *
  *   SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  *******************************************************************************/
-package com.eclipsesource.modelserver.emf.common.codecs;
+package com.eclipsesource.modelserver.common.codecs;
 
-import com.eclipsesource.modelserver.common.codecs.DefaultJsonCodec;
-import com.eclipsesource.modelserver.common.codecs.EncodingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import io.javalin.plugin.json.JavalinJackson;
-import org.eclipse.emf.ecore.EObject;
+public class EncodingException extends Exception {
 
-public class JsonCodec extends DefaultJsonCodec {
-
-    @Override
-    public JsonNode encode(EObject obj) throws EncodingException {
-        return encode((Object) obj);
-    }
-
-    public static JsonNode encode(Object obj) throws EncodingException {
-        try {
-            return JavalinJackson.getObjectMapper().valueToTree(obj);
-        } catch (IllegalArgumentException ex) {
-            throw new EncodingException(ex);
-        }
+    public EncodingException(Exception underlyingCause) {
+        super(underlyingCause);
     }
 }

--- a/com.eclipsesource.modelserver.emf/src/main/java/com/eclipsesource/modelserver/emf/ResourceManager.java
+++ b/com.eclipsesource.modelserver.emf/src/main/java/com/eclipsesource/modelserver/emf/ResourceManager.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
+import com.eclipsesource.modelserver.common.codecs.EMFJsonConverter;
 import org.apache.log4j.Logger;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EObject;

--- a/com.eclipsesource.modelserver.emf/src/main/java/com/eclipsesource/modelserver/emf/common/SessionController.java
+++ b/com.eclipsesource.modelserver.emf/src/main/java/com/eclipsesource/modelserver/emf/common/SessionController.java
@@ -15,8 +15,8 @@
  *******************************************************************************/
 package com.eclipsesource.modelserver.emf.common;
 
-import com.eclipsesource.modelserver.emf.common.codecs.Encoder;
-import com.eclipsesource.modelserver.emf.common.codecs.EncodingException;
+import com.eclipsesource.modelserver.common.codecs.EncodingException;
+import com.eclipsesource.modelserver.emf.common.codecs.Codecs;
 import com.eclipsesource.modelserver.jsonschema.Json;
 import com.google.common.collect.Maps;
 import com.google.inject.Inject;
@@ -44,10 +44,10 @@ public class SessionController extends WsHandler {
 	@Inject
 	private ModelRepository modelRepository;
 
-	private Encoder encoder;
+	private Codecs encoder;
 
 	public SessionController() {
-		this.encoder = new Encoder();
+		this.encoder = new Codecs();
 	}
 
 	public void subscribe(WsContext ctx, String modeluri) {

--- a/com.eclipsesource.modelserver.emf/src/main/java/com/eclipsesource/modelserver/emf/common/codecs/Codecs.java
+++ b/com.eclipsesource.modelserver.emf/src/main/java/com/eclipsesource/modelserver/emf/common/codecs/Codecs.java
@@ -15,21 +15,26 @@
  *******************************************************************************/
 package com.eclipsesource.modelserver.emf.common.codecs;
 
+import com.eclipsesource.modelserver.common.codecs.Codec;
+import com.eclipsesource.modelserver.common.codecs.DecodingException;
+import com.eclipsesource.modelserver.common.codecs.EncodingException;
+import com.eclipsesource.modelserver.common.codecs.XmiCodec;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.javalin.http.Context;
 import io.javalin.websocket.WsContext;
 import org.eclipse.emf.ecore.EObject;
 
+import java.io.IOException;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-public class Encoder {
+public class Codecs {
 
     private Map<String, Codec> formatToCodec = new LinkedHashMap<>();
 
-    public Encoder() {
+    public Codecs() {
         formatToCodec.put("xmi", new XmiCodec());
         formatToCodec.put("json", new JsonCodec());
     }
@@ -40,6 +45,10 @@ public class Encoder {
 
     public JsonNode encode(WsContext context, EObject eObject) throws EncodingException {
         return findFormat(context.queryParamMap()).encode(eObject);
+    }
+
+    public Optional<EObject> decode(Context context, String payload) throws DecodingException {
+        return findFormat(context.queryParamMap()).decode(payload);
     }
 
     private Codec findFormat(Map<String, List<String>> queryParams) {

--- a/com.eclipsesource.modelserver.emf/src/test/java/com/eclipsesource/modelserver/emf/AbstractResourceTest.java
+++ b/com.eclipsesource.modelserver.emf/src/test/java/com/eclipsesource/modelserver/emf/AbstractResourceTest.java
@@ -18,6 +18,7 @@ package com.eclipsesource.modelserver.emf;
 import java.io.IOException;
 import java.util.Collections;
 
+import com.eclipsesource.modelserver.common.codecs.EMFJsonConverter;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;

--- a/com.eclipsesource.modelserver.emf/src/test/java/com/eclipsesource/modelserver/emf/EMFJsonConverterTest.java
+++ b/com.eclipsesource.modelserver.emf/src/test/java/com/eclipsesource/modelserver/emf/EMFJsonConverterTest.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Optional;
 
+import com.eclipsesource.modelserver.common.codecs.EMFJsonConverter;
 import org.apache.commons.io.FileUtils;
 import org.apache.log4j.BasicConfigurator;
 import org.eclipse.emf.ecore.EClass;

--- a/com.eclipsesource.modelserver.emf/src/test/java/com/eclipsesource/modelserver/emf/common/ModelControllerTest.java
+++ b/com.eclipsesource.modelserver.emf/src/test/java/com/eclipsesource/modelserver/emf/common/ModelControllerTest.java
@@ -17,9 +17,9 @@ package com.eclipsesource.modelserver.emf.common;
 
 import com.eclipsesource.modelserver.coffee.model.coffee.BrewingUnit;
 import com.eclipsesource.modelserver.coffee.model.coffee.CoffeeFactory;
-import com.eclipsesource.modelserver.emf.common.codecs.EncodingException;
+import com.eclipsesource.modelserver.common.codecs.EncodingException;
+import com.eclipsesource.modelserver.common.codecs.XmiCodec;
 import com.eclipsesource.modelserver.emf.common.codecs.JsonCodec;
-import com.eclipsesource.modelserver.emf.common.codecs.XmiCodec;
 import com.eclipsesource.modelserver.jsonschema.Json;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.javalin.http.Context;
@@ -109,5 +109,19 @@ public class ModelControllerTest {
         modelController.getOne(context, "test");
 
         assertThat(response.get().get("data"), is(equalTo(new JsonCodec().encode(brewingUnit))));
+    }
+
+    @Test
+    public void updateXmi() throws EncodingException {
+        final BrewingUnit brewingUnit = CoffeeFactory.eINSTANCE.createBrewingUnit();
+        final LinkedHashMap<String, List<String>> queryParams = new LinkedHashMap<>();
+        queryParams.put("format", Collections.singletonList("xmi"));
+        when(context.queryParamMap()).thenReturn(queryParams);
+        when(context.body()).thenReturn(
+            Json.object(Json.prop("data", new XmiCodec().encode(brewingUnit))).toString()
+        );
+        modelController.update(context, "SuperBrewer3000.json");
+        verify(modelRepository, times(1))
+            .updateModel(eq("SuperBrewer3000.json"), any(BrewingUnit.class));
     }
 }


### PR DESCRIPTION
* Move `codecs` package to common
* Move `EMFJsonConverter` to `codecs` package
* Introduce `DefaultJsonCode` as `JavalinJackson` is not available in `common` package. This will be used on the client side to encode and decode to/from JSON & XMI