### PR TITLE
Refactor query param handling, add test for get call via a given format

### DIFF
--- a/com.eclipsesource.modelserver.client/src/main/java/com/eclipsesource/modelserver/client/ModelServerClient.java
+++ b/com.eclipsesource.modelserver.client/src/main/java/com/eclipsesource/modelserver/client/ModelServerClient.java
@@ -241,8 +241,6 @@ public class ModelServerClient implements ModelServerClientApi<EObject>, ModelSe
     	
     	final String format = checkedFormat(_format);
         final String queryParams = modelUri.contains("?") ? modelUri.substring(modelUri.indexOf("?")) : "";
-        final String modelURIParam = queryParams.isEmpty() ? queryParam("modeluri", modelUri) : addQueryParam("modeluri", modelUri);
-        
         Request request = new Request.Builder()
             .url(makeWsUrl(SUBSCRIPTION)
                 .replace(":modeluri", modelUri.substring(0, modelUri.indexOf("?")))

--- a/com.eclipsesource.modelserver.client/src/test/java/com/eclipsesource/modelserver/client/ModelServerClientTest.java
+++ b/com.eclipsesource.modelserver.client/src/test/java/com/eclipsesource/modelserver/client/ModelServerClientTest.java
@@ -75,6 +75,20 @@ public class ModelServerClientTest {
     }
 
     @Test
+    public void getXmi() throws ExecutionException, InterruptedException, EncodingException, MalformedURLException {
+        final BrewingUnit brewingUnit = CoffeeFactory.eINSTANCE.createBrewingUnit();
+        interceptor.addRule()
+            .get()
+            .url(BASE_URL + ModelServerClient.MODEL_BASE_PATH + "?modeluri=SuperBrewer3000.json&format=xmi")
+            .respond(createDataResponse(new XmiCodec().encode(brewingUnit)).toString());
+        ModelServerClient client = createClient();
+
+        final CompletableFuture<Response<EObject>> f = client.get("SuperBrewer3000.json", "xmi");
+
+        assertTrue(EcoreUtil.equals(f.get().body(), brewingUnit));
+    }
+
+    @Test
     public void getAll() throws EncodingException, ExecutionException, InterruptedException, MalformedURLException {
         interceptor.addRule()
             .get()


### PR DESCRIPTION
* Add test case for `ModelServerClient#get(String, String)`
* refactor query param handling 