### PR TITLE
Fix ModelController.executeCommand

### DIFF
--- a/com.eclipsesource.modelserver.emf/src/main/java/com/eclipsesource/modelserver/emf/common/ModelController.java
+++ b/com.eclipsesource.modelserver.emf/src/main/java/com/eclipsesource/modelserver/emf/common/ModelController.java
@@ -192,7 +192,8 @@ public class ModelController {
 									.map(CCommand.class::cast) //
 									.ifPresent(cmd -> {
 										try {
-											modelRepository.updateModel(modelURI, cmd);
+											CCommand copyCommand= EcoreUtil.copy(cmd);
+											modelRepository.updateModel(modelURI, copyCommand);
 											sessionController.modelChanged(modelURI, cmd);
 											ctx.json(JsonResponse.success());
 										} catch (DecodingException e) {


### PR DESCRIPTION
Copy received command and operate on the copy. Broadcast the original command to the subscribers. This ensures that no objects references are removed from the original command